### PR TITLE
[Autofix] Your fixed changes!

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,7 @@
+{
+  "name": "astro-ssg-demo",
+  "compatibility_date": "2025-06-04",
+  "assets": {
+    "directory": "./dist"
+  }
+}


### PR DESCRIPTION
## Project Analysis and Deployment Failure

The project `astro-ssg-demo` is an Astro application configured for static site generation (SSG). The build process (`pnpm run build`) completed successfully, producing static assets in the `/dist` directory. However, the deployment command `npx wrangler deploy` failed with the error: `Missing entry-point to Worker script or to assets directory`.

This failure occurred because there was no `wrangler.jsonc` (or `wrangler.toml`) file to instruct Wrangler on what to deploy. For a static site, Wrangler needs to know the directory containing the static assets.

This project did not require a complex Pages-to-Workers migration as it's a simple static site. The primary fix was to provide the correct Wrangler configuration for deploying static assets.

## Relevant Cloudflare Workers Documentation

The following Cloudflare Workers documentation is relevant for deploying this type of project:

*   **Wrangler Configuration (`wrangler.jsonc`):**
    *   General configuration: [https://developers.cloudflare.com/workers/wrangler/configuration/](https://developers.cloudflare.com/workers/wrangler/configuration/)
    *   Configuring static assets: [https://developers.cloudflare.com/workers/static-assets/binding/](https://developers.cloudflare.com/workers/static-assets/binding/)
*   **Deploying Static Assets with Workers:**
    *   Overview: [https://developers.cloudflare.com/workers/static-assets/](https://developers.cloudflare.com/workers/static-assets/)
    *   Getting Started: [https://developers.cloudflare.com/workers/static-assets/get-started/](https://developers.cloudflare.com/workers/static-assets/get-started/)

Since this is a static Astro site and doesn't use Pages Functions or other advanced Pages features, a full Pages-to-Workers migration guide isn't strictly necessary. The key is to configure Wrangler to serve the static build output.

## Summary of Fixes

1.  **Created `wrangler.jsonc`:**
    *   A `wrangler.jsonc` file was added to the root of the project.
    *   The file content is:
        ```json
        {
          "name": "astro-ssg-demo",
          "compatibility_date": "2025-06-04",
          "assets": {
            "directory": "./dist"
          }
        }
        ```
    *   This configuration tells Wrangler:
        *   The name of the worker is `astro-ssg-demo`.
        *   To use a compatibility date of `2025-06-04`.
        *   The static assets to be deployed are located in the `./dist` directory (which is the output directory of the `astro build` command).

With this `wrangler.jsonc` file in place, the `npx wrangler deploy` command will now correctly identify and deploy the static assets from the `dist` folder. No changes to `package.json` or build commands were necessary for this specific issue.